### PR TITLE
check dc/os is installed before attempting to exec `dcos_install.sh` for v1.11.1

### DIFF
--- a/dcos-versions/1.11.1/dcos-mesos-agent-public/templates/install/run.sh
+++ b/dcos-versions/1.11.1/dcos-mesos-agent-public/templates/install/run.sh
@@ -3,5 +3,19 @@
 # Install Agent Node
 mkdir /tmp/dcos && cd /tmp/dcos
 /usr/bin/curl -O ${bootstrap_private_ip}:${dcos_bootstrap_port}/dcos_install.sh
-bash dcos_install.sh slave_public
+echo "checking for installation.."
+if (
+    # dcos.target exists and is a directory, OR
+    [[ -d /etc/systemd/system/dcos.target ]] ||
+    # dcos.target.wants exists and is a directory, OR
+    [[ -d /etc/systemd/system/dcos.target.wants ]] ||
+    # /opt/mesosphere exists and is not an empty directory
+    ( [[ -a /opt/mesosphere ]] && ( ! empty_dir /opt/mesosphere ) )
+); then
+    echo "previous install found. skipping install"
+    exit 0
+else
+    echo "previous installation not found. executing 'bash dcos_install.sh'"
+    bash dcos_install.sh slave_public
+fi
 # Agent Node End

--- a/dcos-versions/1.11.1/dcos-mesos-agent/templates/install/run.sh
+++ b/dcos-versions/1.11.1/dcos-mesos-agent/templates/install/run.sh
@@ -3,6 +3,20 @@
 # Install Agent Node
 mkdir /tmp/dcos && cd /tmp/dcos
 /usr/bin/curl -O ${bootstrap_private_ip}:${dcos_bootstrap_port}/dcos_install.sh
-bash dcos_install.sh slave
+echo "checking for installation.."
+if (
+    # dcos.target exists and is a directory, OR
+    [[ -d /etc/systemd/system/dcos.target ]] ||
+    # dcos.target.wants exists and is a directory, OR
+    [[ -d /etc/systemd/system/dcos.target.wants ]] ||
+    # /opt/mesosphere exists and is not an empty directory
+    ( [[ -a /opt/mesosphere ]] && ( ! empty_dir /opt/mesosphere ) )
+); then
+    echo "previous install found. skipping install"
+    exit 0
+else
+    echo "previous installation not found. executing 'bash dcos_install.sh'"
+    bash dcos_install.sh slave
+fi
 # Agent Node End
 

--- a/dcos-versions/1.11.1/dcos-mesos-master/templates/install/run.sh
+++ b/dcos-versions/1.11.1/dcos-mesos-master/templates/install/run.sh
@@ -3,5 +3,19 @@
 # Install Master Node
 mkdir /tmp/dcos && cd /tmp/dcos
 /usr/bin/curl -O ${bootstrap_private_ip}:${dcos_bootstrap_port}/dcos_install.sh
-bash dcos_install.sh master
+echo "checking for installation.."
+if (
+    # dcos.target exists and is a directory, OR
+    [[ -d /etc/systemd/system/dcos.target ]] ||
+    # dcos.target.wants exists and is a directory, OR
+    [[ -d /etc/systemd/system/dcos.target.wants ]] ||
+    # /opt/mesosphere exists and is not an empty directory
+    ( [[ -a /opt/mesosphere ]] && ( ! empty_dir /opt/mesosphere ) )
+); then
+    echo "previous install found. skipping install"
+    exit 0
+else
+    echo "previous installation not found. executing 'bash dcos_install.sh'"
+    bash dcos_install.sh master
+fi
 # Master Node End


### PR DESCRIPTION
This code snippet is from `dcos_install.sh` which checks for a pre-existing install. 

This is extracted into `run.sh` so that on `terraform apply`, we skip executing `dcos_install.sh install` which returns a non-zero exit code if an existing install is found.

Without this change, making any changes to the terraform config for a dc/os cluster will always fail on a `terraform apply`.

This change is only being made for a single version `v1.11.1` for our use case. But once this in, we can submit a PR to the upstream repo as a starting point, to get consensus on the general approach to fix this issues and then make the change to all the versions.

linked to https://github.com/quintilesims/terraform-dcos/pull/7